### PR TITLE
BR-51 Update ddf-jaxb to run on changes, instead of nightly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,13 +9,6 @@ pipeline {
         disableConcurrentBuilds()
         timestamps()
     }
-    triggers {
-        /*
-          Restrict nightly builds to master branch, all others will be built on change only.
-          Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
-        */
-        cron(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
-    }
     environment {
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '
         LINUX_MVN_RANDOM = '-Djava.security.egd=file:/dev/./urandom'


### PR DESCRIPTION
## What does this PR do?

The job has been running nightly for months but there has been no changes to the code, so the change will just be to run it if there is a code change. 

This will be done by removing the trigger from the Jenkinsfile

##  Issue 
  #15 

## Reviewers
@shaundmorris
@AdamBurstynski 
@coyotesqrl  
@bdeining  
