### PR TITLE
Switch to Nexus (repo.codice.org)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
       (github.ref == 'refs/heads/master' || contains(github.ref, '.x'))
     runs-on: ubuntu-latest
     environment: production
-    permissions:
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,25 +77,18 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Configure Maven settings
-        uses: s4u/maven-settings-action@v3.0.0
-        with:
-          servers: |
-            [{
-              "id": "releases",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            },
-            {
-              "id": "snapshots",
-              "username": "${{ github.actor }}",
-              "password": "${{ secrets.GITHUB_TOKEN }}"
-            }]
+      - name: Create Maven Settings
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        run: |
+          mkdir -p ~/.m2
+          printf '<settings>\n  <servers>\n    <server>\n      <id>releases</id>\n      <username>%s</username>\n      <password>%s</password>\n    </server>\n    <server>\n      <id>snapshots</id>\n      <username>%s</username>\n      <password>%s</password>\n    </server>\n  </servers>\n</settings>\n' "$NEXUS_USERNAME" "$NEXUS_PASSWORD" "$NEXUS_USERNAME" "$NEXUS_PASSWORD" > ~/.m2/settings.xml
 
       - name: Deploy
         run: |
           mvn deploy $MAVEN_CLI_OPTS \
             -DskipTests=true \
             -DretryFailedDeploymentCount=10 \
-            -DaltReleaseDeploymentRepository=releases::https://maven.pkg.github.com/codice/ddf-jaxb \
-            -DaltSnapshotDeploymentRepository=snapshots::https://maven.pkg.github.com/codice/ddf-jaxb
+            -DaltReleaseDeploymentRepository=releases::https://repo.codice.org/repository/maven-releases/ \
+            -DaltSnapshotDeploymentRepository=snapshots::https://repo.codice.org/repository/maven-snapshots/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   release:
-    uses: codice/release-pipelines/.github/workflows/maven-release.yml@nexus-deploy
+    uses: codice/release-pipelines/.github/workflows/maven-release.yml@main
     with:
       app_name: 'ddf-jaxb'
       branch: ${{ inputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,10 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   release:
-    uses: codice/release-pipelines/.github/workflows/maven-release.yml@main
+    uses: codice/release-pipelines/.github/workflows/maven-release.yml@nexus-deploy
     with:
       app_name: 'ddf-jaxb'
       branch: ${{ inputs.branch }}
@@ -54,3 +53,5 @@ jobs:
       app_private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      nexus_username: ${{ secrets.NEXUS_USERNAME }}
+      nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,11 @@
     <distributionManagement>
         <repository>
             <id>releases</id>
-            <url>http://artifacts.codice.org/content/repositories/releases/</url>
+            <url>https://repo.codice.org/repository/maven-releases/</url>
         </repository>
         <snapshotRepository>
             <id>snapshots</id>
-            <url>http://artifacts.codice.org/content/repositories/snapshots/</url>
+            <url>https://repo.codice.org/repository/maven-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -211,7 +211,7 @@
         <repository>
             <id>codice</id>
             <name>Codice Repository</name>
-            <url>https://artifacts.codice.org/content/groups/public/</url>
+            <url>https://repo.codice.org/repository/maven-public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -227,7 +227,7 @@
         <pluginRepository>
             <id>codice</id>
             <name>Codice Repository</name>
-            <url>https://artifacts.codice.org/content/groups/public/</url>
+            <url>https://repo.codice.org/repository/maven-public/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Update POM repos and CI deploy to use repo.codice.org.